### PR TITLE
improve session-init to avoid deadlock in timeout-case

### DIFF
--- a/include/libKitsunemimiSakuraNetwork/session.h
+++ b/include/libKitsunemimiSakuraNetwork/session.h
@@ -108,9 +108,7 @@ public:
     std::string m_sessionIdentifier = "";
     ErrorContainer sessionError;
 
-    // wait for initialized
-    std::mutex m_cvMutex;
-    std::condition_variable m_cv;
+    int m_initState = 0;
 
     // init session
     bool connectiSession(const uint32_t sessionId,

--- a/src/handler/reply_handler.cpp
+++ b/src/handler/reply_handler.cpp
@@ -235,6 +235,10 @@ ReplyHandler::makeTimerStep()
                                         + std::to_string(temp->completeMessageId)
                                         + " with type: "
                                         + std::to_string(temp->messageType);
+                // release session for the case,
+                // that the session is actually still in creating state.
+                // If this lock is not release, it blocks for eterity.
+                temp->session->m_initState = -1;
 
                 temp->session->m_processError(temp->session,
                                               Session::errorCodes::MESSAGE_TIMEOUT,

--- a/src/messages_processing/error_processing.h
+++ b/src/messages_processing/error_processing.h
@@ -140,6 +140,10 @@ process_Error_Type(Session* session,
                    const CommonMessageHeader* header,
                    const void* rawMessage)
 {
+    // release session for the case, that the session is actually still in creating state. If this
+    // lock is not release, it blocks for eterity.
+    session->m_initState = -1;
+
     switch(header->subType)
     {
         //------------------------------------------------------------------------------------------

--- a/src/session_controller.cpp
+++ b/src/session_controller.cpp
@@ -334,8 +334,18 @@ SessionController::startSession(Network::AbstractSocket* socket,
         SessionHandler::m_sessionHandler->addSession(newId, newSession);
         send_Session_Init_Start(newSession, sessionIdentifier, error);
 
-        std::unique_lock<std::mutex> lock(newSession->m_cvMutex);
-        newSession->m_cv.wait(lock);
+        while(newSession->m_initState == 0) {
+            usleep(10000);
+        }
+
+        if(newSession->m_initState == -1)
+        {
+            newSession->closeSession(error);
+            sleep(1);
+            delete newSession;
+
+            return nullptr;
+        }
 
         return newSession;
     }


### PR DESCRIPTION
## Description

improve session-init to avoid deadlock in timeout-case

## Related Issues

- #152 

## How it was tested?

- ci-pipeline and some manually testing where the connection-target was blocked by the debugger to enforce timeouts.
